### PR TITLE
Add "Are we already on HTTPS" check

### DIFF
--- a/index.php
+++ b/index.php
@@ -46,7 +46,7 @@ $loadavg = new LoadAvg();
 $settings = LoadAvg::$_settings->general;
 
 /* Force https when in https mode */
-if ( $settings['https'] == "true" ) {
+if ( $settings['https'] == "true" && !isset($_SERVER["HTTPS"])) {
 	header("Location: https://" . $_SERVER['SERVER_NAME'] .$_SERVER['REQUEST_URI']);
 } else {
 	header("Location: public/");


### PR DESCRIPTION
When just checking if https setting is true, we get into a loop if we're already on HTTPS. By checking whether PHP's 'https' value is set, we avoid the loop. (Note: Documentation says "non-empty" for https, so if it isn't set when we're on HTTP)
