### PR TITLE
Make the charts work when LoadAvg is NOT in the site root

### DIFF
--- a/app/views/chart.php
+++ b/app/views/chart.php
@@ -49,7 +49,7 @@
 
 				<!-- parse_ini_file(APP_PATH . '/config/' . self::$settings_ini, true) -->
 
-				<script type="text/javascript" src= "<?php if (isset($APP_PATH)) echo $APP_PATH; ?>/lib/modules/<?php echo $module; ?>/<?php echo strtolower($module); ?>.js"></script>
+				<script type="text/javascript" src= "<?php if (isset($APP_PATH)) { echo $APP_PATH; } else { echo '..'; } ?>/lib/modules/<?php echo $module; ?>/<?php echo strtolower($module); ?>.js"></script>
 				<?php }	?>
 				<script type="text/javascript">
 				(function () {

--- a/lib/modules/Network/views/chart.php
+++ b/lib/modules/Network/views/chart.php
@@ -21,7 +21,7 @@
 <script type="text/javascript" src="lib/modules/<?php echo $module; ?>/<?php echo strtolower($module); ?>.js"></script>
 -->
 
-<script type="text/javascript" src= "<?php if (isset($APP_PATH)) echo $APP_PATH; ?>/lib/modules/<?php echo $module; ?>/<?php echo strtolower($module); ?>.js"></script>
+<script type="text/javascript" src= "<?php if (isset($APP_PATH)) { echo $APP_PATH; } else { echo '..'; } ?>/lib/modules/<?php echo $module; ?>/<?php echo strtolower($module); ?>.js"></script>
 
 <!-- loop through each interface -->
 


### PR DESCRIPTION
A fix for http://www.loadavg.com/forums/topic/no-charts/. In the case where the app is at the root then the browser should ignore the "..", as it doesn't make sense.
