### PR TITLE
Make sure network graphs never show negative transfer

### DIFF
--- a/lib/modules/Network/class.Network.php
+++ b/lib/modules/Network/class.Network.php
@@ -156,7 +156,7 @@ class Network extends LoadAvg
 				$data = explode("|", $contents[$i]);
 
 				// clean data for missing values
-				if (  (!$data[1]) ||  ($data[1] == null) || ($data[1] == "") )
+				if (  (!$data[1]) ||  ($data[1] == null) || ($data[1] == "") || (int)$data[1] < 0)
 					$data[1]=0;
 			
 				$net_rate = $data[1];
@@ -302,6 +302,9 @@ class Network extends LoadAvg
 
 			for ( $i = 0; $i < count( $contents )-1; $i++) {
 				$data = explode("|", $contents[$i]);
+
+				if ( (int)$data[2] < 0 )
+					$data[2] = 0;
 
 				$net_rate = $data[2];
 				$time[$net_rate] = date("H:ia", $data[0]);


### PR DESCRIPTION
(Logically, this shouldn't happen, but in the case of server crashes then counters can get reset/lost)
