### PR TITLE
Fix undefined index and static call warnings, plus cache the timezones

### DIFF
--- a/app/views/settings.php
+++ b/app/views/settings.php
@@ -314,7 +314,7 @@ header('Location: '.$_SERVER['REQUEST_URI']);
 				<div class="toggle-button" data-togglebutton-style-enabled="success" style="width: 100px; height: 25px;">
                     <input name="settings[network_interface][<?php echo trim($interface['name']); ?>]" value="true" type="checkbox" 
                     	<?php 
-                    		if ( $settings['network_interface'][trim($interface['name'])] == "true" ) 
+                    		if ( isset($settings['network_interface'][trim($interface['name'])]) && $settings['network_interface'][trim($interface['name'])] == "true" ) 
                     		{ ?>checked="checked"<?php } 
                     	?>
                     >
@@ -338,7 +338,7 @@ header('Location: '.$_SERVER['REQUEST_URI']);
                     <div class="span9 right">
                         <div class="toggle-button" data-togglebutton-style-enabled="success" style="width: 100px; height: 25px;">
                             <input name="settings[modules][<?php echo $module; ?>]" value="true" type="checkbox" 
-                            	<?php if ( $settings['modules'][$module] == "true" ) 
+                            	<?php if ( isset($settings['modules'][$module]) && $settings['modules'][$module] == "true" ) 
                             		{ ?>checked="checked"<?php } 
                             	?>
                             >

--- a/lib/class.LoadAvg.php
+++ b/lib/class.LoadAvg.php
@@ -19,6 +19,7 @@ class LoadAvg
 	public static $_classes; // storing loaded modules classes
 	public static $_modules; // storing loaded modules
 	public static $current_date; // current date
+	private static $_timezones; // Cache of timezones
 	
 	// Periodas
 	public static $period;
@@ -550,14 +551,17 @@ class LoadAvg
 	/**
 	 * getTimezones
 	 *
-	 * Checks for new versions of LoadAvg
+	 * Get the (cached) list of all possible timezones
 	 *
 	 */
 
-	public function getTimezones()
+	public static function getTimezones()
 	{
-
-		$timezones = array();
+		if (is_array(LoadAvg::$_timezones)) {
+			return LoadAvg::$_timezones;
+		}
+		
+		LoadAvg::$_timezones = array();
 		
 		$regions = array(
 		    'Africa' => DateTimeZone::AFRICA,
@@ -582,11 +586,11 @@ class LoadAvg
 				$ampm = $time->format('H') > 12 ? ' ('. $time->format('g:i a'). ')' : '';
 		 
 				// Remove region name and add a sample time
-				$timezones[$name][$timezone] = substr($timezone, strlen($name) + 1) . ' - ' . $time->format('H:i') . $ampm;
+				LoadAvg::$_timezones[$name][$timezone] = substr($timezone, strlen($name) + 1) . ' - ' . $time->format('H:i') . $ampm;
 			}
 		}
 		
-		return $timezones;
+		return LoadAvg::$_timezones;
 
 	}
 


### PR DESCRIPTION
If settings aren't set to true then they don't exist, so do a "isset" first to check.

The getTimezone method was non-static but being called statically. As well as making it static, it might as well be cached to save generating it again on any later calls.

LoadAvg now runs without generating any warnings (for me).
